### PR TITLE
[Doc] Add '-ud' to bcc documentation.

### DIFF
--- a/docs/tools/bcc.md
+++ b/docs/tools/bcc.md
@@ -99,3 +99,7 @@ Sets requirement for overriding methods and functions to append `override` to th
 #### `-overerr`
 
 Defines missing `override` keywords in overridden methods and functions to be handled as error instead of warning.
+
+#### `-ud <custom conditionals>`
+
+Add custom conditionals (comma separated) then usable via `?myconditional`.


### PR DESCRIPTION
Github decided to alter line endings (maybe because I edited the page on Windows?)

> We’ve detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style