### PR TITLE
Add `blitzmax-mode` to list of IDE's

### DIFF
--- a/docs/community/ides.md
+++ b/docs/community/ides.md
@@ -24,6 +24,11 @@ Topic: http://mojolabs.nz/posts.php?topic=98327
 Repo: https://github.com/GWRon/blitzmax-geany-plugin
 
 
+## Emacs extension
+Site: https://www.sodaware.net/dev/tools/blitzmax-mode/
+
+Repo: https://github.com/sodaware/blitzmax-mode
+
 
 # Unmaintained
 


### PR DESCRIPTION
`blitzmax-mode` is an Emacs package I created for editing BlitzMax files.